### PR TITLE
Added more client apis

### DIFF
--- a/lib/namecheap/dns.rb
+++ b/lib/namecheap/dns.rb
@@ -1,0 +1,51 @@
+module Namecheap
+  class Dns < Api
+    def set_default(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.dns.setDefault', args)
+    end
+
+    def set_custom(sld, tld, nameservers = [], options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      args['Nameservers'] = nameservers.respond_to?(:join) ? nameservers.join(',') : nameservers
+      api_call('namecheap.domains.dns.setCustom', args)
+    end
+
+    def get_list(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.dns.getList', args)
+    end
+
+    def get_hosts(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.dns.getHosts', args)
+    end
+
+    def get_email_forwarding(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.dns.getEmailForwarding', args)
+    end
+
+    def set_email_forwarding(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.dns.setEmailForwarding', args)
+    end
+
+    def set_hosts(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.dns.setHosts', args)
+    end
+  end
+end

--- a/lib/namecheap/domains.rb
+++ b/lib/namecheap/domains.rb
@@ -5,10 +5,63 @@ module Namecheap
       api_call('namecheap.domains.getList', args)
     end
 
+    def get_contacts(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.getContacts', args)
+    end
+
+    def create(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.create', args)
+    end
+
+    def get_tld_list(options = {})
+      args = options.clone
+      api_call('namecheap.domains.getTldList', args)
+    end
+
+    def set_contacts(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.setContacts', args)
+    end
+
     def check(domains = [], options = {})
       args = options.clone
       args['DomainList'] = domains.respond_to?(:join) ? domains.join(',') : domains
       api_call('namecheap.domains.check', args)
+    end
+
+    def reactivate(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.reactivate', args)
+    end
+
+    def renew(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.renew', args)
+    end
+
+    def get_registrar_lock(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.getRegistrarLock', args)
+    end
+
+    def set_registrar_lock(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.setRegistrarLock', args)
+    end
+
+    def get_info(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.getInfo', args)
     end
   end
 end

--- a/lib/namecheap/ns.rb
+++ b/lib/namecheap/ns.rb
@@ -1,0 +1,31 @@
+module Namecheap
+  class Ns < Api
+    def create(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.ns.create', args)
+    end
+
+    def delete(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.ns.delete', args)
+    end
+
+    def get_info(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.ns.getInfo', args)
+    end
+
+    def update(sld, tld, options = {})
+      args = options.clone
+      args['SLD'] = sld
+      args['TLD'] = tld
+      api_call('namecheap.domains.ns.update', args)
+    end
+  end
+end

--- a/lib/namecheap/ssl.rb
+++ b/lib/namecheap/ssl.rb
@@ -1,0 +1,60 @@
+module Namecheap
+  class Ssl < Api
+    def activate(id, options = {})
+      args = options.clone
+      args['CertificateID'] = id
+      api_call('namecheap.ssl.activate', args)
+    end
+
+    def get_info(id, options = {})
+      args = options.clone
+      args['CertificateID'] = id
+      api_call('namecheap.ssl.getInfo', args)
+    end
+
+    def parse_csr(csr, options = {})
+      args = options.clone
+      args['csr'] = csr
+      api_call('namecheap.ssl.parseCSR', args)
+    end
+
+    def get_approver_email_list(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.ssl.getApproverEmailList', args)
+    end
+
+    def get_list(options = {})
+      args = options.clone
+      api_call('namecheap.ssl.getList', args)
+    end
+
+    def create(options = {})
+      args = options.clone
+      api_call('namecheap.ssl.create', args)
+    end
+
+    def renew(options = {})
+      args = options.clone
+      api_call('namecheap.ssl.renew', args)
+    end
+
+    def resend_approver_email(id, options = {})
+      args = options.clone
+      args['CertificateID'] = id
+      api_call('namecheap.ssl.resendApproverEmail', args)
+    end
+
+    def resend_fulfillment_email(id, options = {})
+      args = options.clone
+      args['CertificateID'] = id
+      api_call('namecheap.ssl.resendfulfillmentemail', args)
+    end
+
+    def reissue(id, options = {})
+      args = options.clone
+      args['CertificateID'] = id
+      api_call('namecheap.ssl.reissue', args)
+    end
+  end
+end

--- a/lib/namecheap/transfers.rb
+++ b/lib/namecheap/transfers.rb
@@ -1,0 +1,26 @@
+module Namecheap
+  class Transfers < Api
+    def create(domain, options = {})
+      args = options.clone
+      args['DomainName'] = domain
+      api_call('namecheap.domains.transfer.create', args)
+    end
+
+    def get_status(id, options = {})
+      args = options.clone
+      args['TransferID'] = id
+      api_call('namecheap.domains.transfer.getStatus', args)
+    end
+
+    def update_status(id, options = {})
+      args = options.clone
+      args['TransferID'] = id
+      api_call('namecheap.domains.transfer.updateStatus', args)
+    end
+    
+    def get_list(options = {})
+      args = options.clone
+      api_call('namecheap.domains.transfer.getList', args)
+    end
+  end
+end

--- a/lib/namecheap/users.rb
+++ b/lib/namecheap/users.rb
@@ -1,0 +1,44 @@
+module Namecheap
+  class Users < Api
+    def get_pricing(options = {})
+      args = options.clone
+      api_call('namecheap.users.getPricing', args)
+    end
+
+    def get_balances(options = {})
+      args = options.clone
+      api_call('namecheap.users.getBalances', args)
+    end
+
+    def change_password(options = {})
+      args = options.clone
+      api_call('namecheap.users.changePassword', args)
+    end
+
+    def update(options = {})
+      args = options.clone
+      api_call('namecheap.users.update', args)
+    end
+
+    def create_add_funds_request(options = {})
+      args = options.clone
+      api_call('namecheap.users.createaddfundsrequest', args)
+    end
+
+    def get_add_funds_status(id, options = {})
+      args = options.clone
+      args['TokenId'] = id
+      api_call('namecheap.users.getAddFundsStatus', args)
+    end
+
+    def login(options = {})
+      args = options.clone
+      api_call('namecheap.users.login', args)
+    end
+
+    def reset_password(options = {})
+      args = options.clone
+      api_call('namecheap.users.resetPassword', args)
+    end
+  end
+end

--- a/lib/namecheap/whois_guard.rb
+++ b/lib/namecheap/whois_guard.rb
@@ -1,0 +1,40 @@
+module Namecheap
+  class Whois_Guard < Api
+    def allot(id, domain, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      args['DomainName'] = domain
+      api_call('namecheap.whoisguard.allot', args)
+    end
+
+    def discard(id, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      api_call('namecheap.whoisguard.discard', args)
+    end
+
+    def unallot(id, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      api_call('namecheap.whoisguard.unallot', args)
+    end
+
+    def disable(id, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      api_call('namecheap.whoisguard.disable', args)
+    end
+
+    def enable(id, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      api_call('namecheap.whoisguard.enable', args)
+    end
+
+    def change_email_address(id, options = {})
+      args = options.clone
+      args['WhoisguardId'] = id
+      api_call('namecheap.whoisguard.changeemailaddress', args)
+    end
+  end
+end


### PR DESCRIPTION
Added some more apis that I need to register a domain.

I hope to look into removing Rails as a requirement and standardize responses rather than having to parse the response from Namecheap manually and catch errors.

I also didn't add the users.address API as I wasn't sure where to put it.

Are you looking for a collaborator? Have you tried contacting hashrocket to do a pull request? His seems to have more stars, would be nice to have one that is the main one as it was hard to find when searching.

http://stackoverflow.com/questions/16422457/how-do-i-use-the-namecheap-gem
