### PR TITLE
Add explicit requires and remove load path

### DIFF
--- a/lib/namecheap.rb
+++ b/lib/namecheap.rb
@@ -1,9 +1,16 @@
 require 'httparty'
 require 'monkey_patch'
 require 'pp'
-
-$LOAD_PATH.unshift("#{File.dirname(__FILE__)}/namecheap")
-Dir.glob("#{File.dirname(__FILE__)}/namecheap/*.rb") { |lib| require File.basename(lib, '.*') }
+require 'namecheap/version'
+require 'namecheap/api'
+require 'namecheap/config'
+require 'namecheap/domains'
+require 'namecheap/dns'
+require 'namecheap/ns'
+require 'namecheap/ssl'
+require 'namecheap/transfers'
+require 'namecheap/users'
+require 'namecheap/whois_guard'
 
 module Namecheap
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -6,5 +6,5 @@ rescue LoadError
   require 'spec'
 end
 
-require File.dirname(__FILE__) + '/../lib/namecheap'
-$LOAD_PATH.unshift("#{File.dirname(__FILE__)}/../lib/namecheap")
+$:.unshift File.expand_path('../../lib',__FILE__)
+require 'namecheap'

--- a/spec/namecheap/dns_spec.rb
+++ b/spec/namecheap/dns_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Dns do
   it 'should initialize' do

--- a/spec/namecheap/domains_spec.rb
+++ b/spec/namecheap/domains_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Domains do
   it 'should initialize' do

--- a/spec/namecheap/ns_spec.rb
+++ b/spec/namecheap/ns_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Ns do
   it 'should initialize' do

--- a/spec/namecheap/ssl_spec.rb
+++ b/spec/namecheap/ssl_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Ssl do
   it 'should initialize' do

--- a/spec/namecheap/transfers.rb
+++ b/spec/namecheap/transfers.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Transfers do
   it 'should initialize' do

--- a/spec/namecheap/users_spec.rb
+++ b/spec/namecheap/users_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Users do
   it 'should initialize' do

--- a/spec/namecheap/whois_guard_spec.rb
+++ b/spec/namecheap/whois_guard_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../helper'
+require 'helper'
 
 describe Namecheap::Whois_Guard do
   it 'should initialize' do


### PR DESCRIPTION
Thanks for providing a nice gem!
I tried to use it, but ran into problems with the require:

```
`<module:Namecheap>': uninitialized constant Namecheap::Api (NameError)
```

I looked into the issue and found in the doc of the glob method (http://www.ruby-doc.org/core-2.1.0/Dir.html#method-c-glob):
"Note that case sensitivity depends on your system (so File::FNM_CASEFOLD is ignored), as does the order in which the results are returned."

The problem was that the `api.rb` was listed after the `transfers.rb`. I changed that to explicit `require` calls and changed the require in the spec helper too.
