### PR TITLE
Created a mechanism for forcing sandbox use

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ Namecheap.domains.get_list
 
 Please see the Namecheap API documentation for more information
 
+The configuration code will determine the active environment (production
+or sandbox in Namecheap terms) and use the appropriate URL.
+To force the gem to always use the sandbox, set **sandbox = true** in
+the configuration, as follows:
+
+```ruby
+Namecheap.configure do |config|
+  config.key = 'apikey'
+  config.username = 'apiuser'
+  config.client_ip = '127.0.0.1'
+  config.sandbox = true
+end
+```
+
 About this project
 -------------
 

--- a/lib/namecheap/api.rb
+++ b/lib/namecheap/api.rb
@@ -2,11 +2,6 @@ require 'active_support/core_ext/string/inflections'
 
 module Namecheap
   class Api
-    SANDBOX = 'https://api.sandbox.namecheap.com/xml.response'
-    PRODUCTION = 'https://api.namecheap.com/xml.response'
-    ENVIRONMENT = defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : (ENV["RACK_ENV"] || 'development')
-    ENDPOINT = (ENVIRONMENT == 'production' ? PRODUCTION : SANDBOX)
-
     def get(command, options = {})
       request 'get', command, options
     end
@@ -33,13 +28,13 @@ module Namecheap
       case method
       when 'get'
         #raise options.inspect
-        HTTParty.get(ENDPOINT, { :query => options})
+        HTTParty.get(Namecheap.config.api_url, { :query => options})
       when 'post'
-        HTTParty.post(ENDPOINT, { :query => options})
+        HTTParty.post(Namecheap.config.api_url, { :query => options})
       when 'put'
-        HTTParty.put(ENDPOINT, { :query => options})
+        HTTParty.put(Namecheap.config.api_url, { :query => options})
       when 'delete'
-        HTTParty.delete(ENDPOINT, { :query => options})
+        HTTParty.delete(Namecheap.config.api_url, { :query => options})
       end
     end
 

--- a/lib/namecheap/config.rb
+++ b/lib/namecheap/config.rb
@@ -3,7 +3,11 @@ module Namecheap
     class RequiredOptionMissing < RuntimeError ; end
     extend self
 
-    attr_accessor :key, :username, :client_ip
+    SANDBOX = 'https://api.sandbox.namecheap.com/xml.response'
+    PRODUCTION = 'https://api.namecheap.com/xml.response'
+
+    attr_accessor :key, :username, :client_ip, :sandbox
+    attr_writer :api_url
 
     # Configure namecheap from a hash. This is usually called after parsing a
     # yaml config file such as mongoid.yml.
@@ -18,15 +22,47 @@ module Namecheap
       end
     end
 
+    # Return the Rails (or other) environment. This is computed from an
+    # environment variable or if we're in a sandbox then "development".
+    #
+    # @example Retrieve the operating environment for the API.
+    #    env = Namecheap.environment
+    #
+    # @param [ String ] env The configured environment (development, test, production, etc).
+    def environment
+      if @sandbox
+        'development'
+      else
+        defined?(Rails) && Rails.respond_to?(:env) ? Rails.env : (ENV["RACK_ENV"] || 'development')
+      end
+    end
+
+    # Return the Namecheap URL. The URL can also be specified in the
+    # configuration block.
+    #
+    # @example Retrieve the URL used by the API.
+    #   uri = URI(Namecheap.api_url)
+    #
+    # @param [ String ] url The configured URL for the service.
+    def api_url
+      if @api_url
+        @api_url
+      elsif environment == 'production'
+        PRODUCTION
+      else
+        SANDBOX
+      end
+    end
+
     # Load the settings from a compliant namecheap.yml file. This can be used for
     # easy setup with frameworks other than Rails.
     #
     # @example Configure Namecheap.
-    #   Namecheap.load!("/path/to/namecheap.yml")
+    #   Namecheap::Config.load!("/path/to/namecheap.yml")
     #
     # @param [ String ] path The path to the file.
     def load!(path)
-      settings = YAML.load(ERB.new(File.new(path).read).result)[ENVIRONMENT]
+      settings = YAML.load(ERB.new(File.new(path).read).result)[environment]
       if settings.present?
         from_hash(settings)
       end

--- a/lib/namecheap/version.rb
+++ b/lib/namecheap/version.rb
@@ -1,3 +1,3 @@
 module Namecheap
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end


### PR DESCRIPTION
In an effort to ensure that the sandbox environment and not the production environment is in use, I added a :sandbox boolean to the configuration. I also added a configuration option to hard-wire the API URL should that be necessary. Fixed a bug with how YAML config loading worked, as well. Previously, the ENVIRONMENT variable was not defined, during the YAML parse.