### PR TITLE
Add explicit legacy environment selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix YAML configuration loading on modern Ruby.
 - Replace accidental live-network specs with deterministic request tests.
 - Modernize gem metadata, development tooling, and documentation.
+- Allow sandbox or production selection independently of the Rails/Rack environment.
 
 ## 0.3.0 (2014-08-18)
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ Namecheap.configure do |config|
 end
 ```
 
+Applications can select the Namecheap environment independently of `RACK_ENV`
+or `Rails.env`. This is useful when a staging application runs in production
+mode but must continue using Namecheap's sandbox:
+
+```ruby
+Namecheap.configure do |config|
+  config.environment = "sandbox"
+end
+```
+
+Set `environment` to either `"sandbox"` or `"production"`. Leave it unset, or
+set it to `nil`, to retain automatic Rails/Rack environment selection.
+
 Avoid committing API keys or account configuration to source control.
 
 ## Usage
@@ -55,6 +68,7 @@ development:
   username: sandbox_user
   key: <%= ENV.fetch("NAMECHEAP_API_KEY") %>
   client_ip: 192.0.2.1
+  environment: sandbox
 ```
 
 ```ruby

--- a/lib/namecheap/api.rb
+++ b/lib/namecheap/api.rb
@@ -32,13 +32,13 @@ module Namecheap
 
       case method
       when "get"
-        HTTParty.get(ENDPOINT, query: options)
+        HTTParty.get(endpoint, query: options)
       when "post"
-        HTTParty.post(ENDPOINT, query: options)
+        HTTParty.post(endpoint, query: options)
       when "put"
-        HTTParty.put(ENDPOINT, query: options)
+        HTTParty.put(endpoint, query: options)
       when "delete"
-        HTTParty.delete(ENDPOINT, query: options)
+        HTTParty.delete(endpoint, query: options)
       end
     end
 
@@ -57,6 +57,19 @@ module Namecheap
         api_key: Namecheap.config.key,
         client_ip: Namecheap.config.client_ip
       }
+    end
+
+    private
+
+    def endpoint
+      case Namecheap.config.environment
+      when "sandbox"
+        SANDBOX
+      when "production"
+        PRODUCTION
+      else
+        ENDPOINT
+      end
     end
   end
 end

--- a/lib/namecheap/config.rb
+++ b/lib/namecheap/config.rb
@@ -6,7 +6,20 @@ module Namecheap
     class RequiredOptionMissing < RuntimeError; end
     extend self
 
+    ENVIRONMENTS = %w[sandbox production].freeze
+
     attr_accessor :key, :username, :client_ip
+    attr_reader :environment
+
+    def environment=(environment)
+      if environment.nil?
+        @environment = nil
+      elsif ENVIRONMENTS.include?(environment)
+        @environment = environment
+      else
+        raise ArgumentError, "environment must be sandbox or production"
+      end
+    end
 
     # Configure namecheap from a hash. This is usually called after parsing a
     # yaml config file such as mongoid.yml.

--- a/spec/namecheap/api_spec.rb
+++ b/spec/namecheap/api_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe Namecheap::Api do
 
   before { set_dummy_config }
 
+  it "preserves the legacy init_args visibility" do
+    expect(api).to respond_to(:init_args)
+  end
+
   describe "configuration validation" do
     %i[username key client_ip].each do |option|
       it "identifies a missing #{option}" do
@@ -47,6 +51,24 @@ RSpec.describe Namecheap::Api do
       )
 
       api.get("domains.getList", client_ip: "192.0.2.10")
+    end
+
+    it "forces sandbox requests independently of the inferred environment" do
+      stub_const("#{described_class}::ENDPOINT", described_class::PRODUCTION)
+      Namecheap.config.environment = "sandbox"
+
+      expect(HTTParty).to receive(:get).with(described_class::SANDBOX, anything)
+
+      api.get("domains.getList")
+    end
+
+    it "forces production requests independently of the inferred environment" do
+      stub_const("#{described_class}::ENDPOINT", described_class::SANDBOX)
+      Namecheap.config.environment = "production"
+
+      expect(HTTParty).to receive(:get).with(described_class::PRODUCTION, anything)
+
+      api.get("domains.getList")
     end
   end
 end

--- a/spec/namecheap_spec.rb
+++ b/spec/namecheap_spec.rb
@@ -12,21 +12,43 @@ RSpec.describe Namecheap do
         config.key = "the_apikey"
         config.username = "the_username"
         config.client_ip = "192.0.2.1"
+        config.environment = "sandbox"
       end
 
       expect(described_class.config.key).to eq("the_apikey")
       expect(described_class.config.username).to eq("the_username")
       expect(described_class.config.client_ip).to eq("192.0.2.1")
+      expect(described_class.config.environment).to eq("sandbox")
     end
   end
 
   describe Namecheap::Config do
     it "loads known options from a hash and ignores unknown options" do
-      described_class.from_hash("username" => "user", "key" => "secret", "unknown" => "ignored")
+      described_class.from_hash(
+        "username" => "user",
+        "key" => "secret",
+        "environment" => "production",
+        "unknown" => "ignored"
+      )
 
       expect(described_class.username).to eq("user")
       expect(described_class.key).to eq("secret")
+      expect(described_class.environment).to eq("production")
       expect(described_class).not_to respond_to(:unknown)
+    end
+
+    ["staging", :sandbox, ""].each do |environment|
+      it "rejects unsupported Namecheap environment #{environment.inspect}" do
+        expect { described_class.environment = environment }
+          .to raise_error(ArgumentError, "environment must be sandbox or production")
+      end
+    end
+
+    it "uses nil to restore automatic environment selection" do
+      described_class.environment = "production"
+
+      expect { described_class.environment = nil }
+        .to change(described_class, :environment).from("production").to(nil)
     end
 
     it "loads the current environment from an ERB-enabled YAML file" do
@@ -36,6 +58,7 @@ RSpec.describe Namecheap do
           username: <%= "yaml_user" %>
           key: yaml_key
           client_ip: 192.0.2.2
+          environment: sandbox
       YAML
       file.close
 
@@ -44,6 +67,7 @@ RSpec.describe Namecheap do
       expect(described_class.username).to eq("yaml_user")
       expect(described_class.key).to eq("yaml_key")
       expect(described_class.client_ip).to eq("192.0.2.2")
+      expect(described_class.environment).to eq("sandbox")
     ensure
       file&.unlink
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,12 +6,14 @@ module ConfigHelpers
     Namecheap.config.username = nil
     Namecheap.config.key = nil
     Namecheap.config.client_ip = nil
+    Namecheap.config.environment = nil
   end
 
   def set_dummy_config
     Namecheap.config.username = "the_username"
     Namecheap.config.key = "the_key"
     Namecheap.config.client_ip = "127.0.0.1"
+    Namecheap.config.environment = nil
   end
 end
 


### PR DESCRIPTION
## Summary

- allow legacy clients to explicitly select Namecheap's `sandbox` or `production` environment
- preserve Rails/Rack endpoint inference when no environment is configured
- validate configuration and cover block, hash, YAML, and HTTP request behavior
- retain the existing endpoint constants and public method visibility

## Background

This supersedes #10, originally proposed by @jkassemi. That contribution identified a real deployment problem: a staging application may run with `Rails.env == "production"` while still needing to use Namecheap's sandbox.

The original proposal accepted an arbitrary endpoint URL. This replacement uses a validated `sandbox`/`production` selector, matching the current v2 client while preserving the legacy fallback behavior.

This also covers the forced-sandbox use case proposed by @dtynan in #15.

No gem version is changed and no release is performed.

## Validation

- `mise exec -- bundle exec rake` — 78 examples, 0 failures; Standard passes
- `mise exec -- bundle exec gem build namecheap.gemspec` — builds `namecheap-0.3.1.gem`