### PR TITLE
Add configurable request timeouts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,12 +65,19 @@ prefixes. Issue numbers are encouraged for traceability, not required. Use this
 sequence when choosing a branch name:
 
 1. Check whether the task has a parent issue.
-2. When a parent issue exists, encourage
+2. Before making file changes for work tied to a GitHub issue, check the current
+   branch and existing local branches. If the current branch is unrelated but a
+   matching issue branch already exists, treat the work as a possible
+   continuation and switch to that branch. If no matching branch exists, ask
+   the user whether to create an issue branch before editing.
+3. When a parent issue exists, encourage
    `<issue-number>-<short-description>`, such as `19-request-timeouts`.
-3. When no parent issue exists, recommend creating one for traceability.
-4. If the user prefers not to create an issue, respect that decision and use a
+4. When no parent issue exists, recommend creating one for traceability.
+5. If the user prefers not to create an issue, respect that decision and use a
    concise descriptive name such as `refresh-readme-examples`.
-5. Respect an explicit branch name chosen by the user.
+6. Respect an explicit branch name chosen by the user.
+7. After a topic branch has been merged, offer to delete both its local and
+   remote copies. Do not delete either branch without the user's confirmation.
 
 ## Security & Releases
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - Expose every API operation through the CLI, including structured private input for secrets and guarded unquotable charges.
 - Cover all 59 commands in Namecheap's current API catalog, including user addresses and the latest SSL operations.
 - Return normalized response objects with raw XML access and raise typed API, transport, and parse errors.
+- Add configurable open and read timeouts and reuse one Faraday connection
+  across each client's resources.
 - Add verified, signed-tag release automation using RubyGems trusted publishing.
 - Promote v2 development to `main` and preserve the old 0.3 line as `legacy/0.3`.
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,20 @@ client = Namecheap::API::Client.new(
   api_key: ENV.fetch("NAMECHEAP_API_KEY"),
   user_name: ENV.fetch("NAMECHEAP_USERNAME"),
   client_ip: ENV.fetch("NAMECHEAP_CLIENT_IP"),
-  environment: "sandbox"
+  environment: "sandbox",
+  open_timeout: 5,
+  read_timeout: 30
 )
 ```
 
-`user_name` defaults to `api_user`, and `environment` defaults to `sandbox`. The API user, key, username, and [whitelisted client IP](https://www.namecheap.com/support/api/global-parameters/) must be non-empty. The environment must be either `sandbox` or `production`.
+`user_name` defaults to `api_user`, and `environment` defaults to `sandbox`.
+Connections default to a 5-second open timeout and a 30-second read timeout;
+both accept custom positive finite numbers. One connection is reused by all
+resources belonging to the client.
+
+The API user, key, username, and
+[whitelisted client IP](https://www.namecheap.com/support/api/global-parameters/)
+must be non-empty. The environment must be either `sandbox` or `production`.
 
 Configuration values must be strings without surrounding whitespace, and
 `client_ip` must be a valid IPv4 address. The client exposes only its

--- a/lib/namecheap/api/base.rb
+++ b/lib/namecheap/api/base.rb
@@ -12,8 +12,17 @@ module Namecheap
       PRODUCTION = "https://api.namecheap.com/xml.response"
       PROTECTED_FIELDS = %w[api_user api_key user_name client_ip command].freeze
 
-      def initialize(config)
+      def self.build_connection(open_timeout:, read_timeout:)
+        Faraday.new do |connection|
+          connection.options.open_timeout = open_timeout
+          connection.options.timeout = read_timeout
+          connection.request :url_encoded
+        end
+      end
+
+      def initialize(config, connection:)
         @config = config
+        @connection = connection
         @environment = config[:environment]
         @query = {
           "ApiUser" => config[:api_user],
@@ -62,14 +71,14 @@ module Namecheap
       end
 
       def get(url, command)
-        response = Faraday.get(url)
+        response = @connection.get(url)
         response_for(response, command)
       rescue Faraday::Error => error
         raise TransportError.new("Namecheap request failed: #{error.class}", command: command)
       end
 
       def post(url, params, command)
-        response = Faraday.post(url, params)
+        response = @connection.post(url, params)
         response_for(response, command)
       rescue Faraday::Error => error
         raise TransportError.new("Namecheap request failed: #{error.class}", command: command)

--- a/lib/namecheap/api/client.rb
+++ b/lib/namecheap/api/client.rb
@@ -8,6 +8,8 @@ module Namecheap
   module API
     class Client
       ENVIRONMENTS = %w[sandbox production].freeze
+      DEFAULT_OPEN_TIMEOUT = 5
+      DEFAULT_READ_TIMEOUT = 30
 
       attr_reader :environment
 
@@ -16,11 +18,15 @@ module Namecheap
         api_key:,
         client_ip:,
         user_name: api_user,
-        environment: "sandbox"
+        environment: "sandbox",
+        open_timeout: DEFAULT_OPEN_TIMEOUT,
+        read_timeout: DEFAULT_READ_TIMEOUT
       )
         validate_strings!(api_user: api_user, api_key: api_key, user_name: user_name, client_ip: client_ip)
         validate_ipv4!(client_ip)
         validate_environment!(environment)
+        validate_timeout!(:open_timeout, open_timeout)
+        validate_timeout!(:read_timeout, read_timeout)
 
         @config = {
           api_user: immutable_string(api_user),
@@ -30,22 +36,23 @@ module Namecheap
           environment: immutable_string(environment)
         }.freeze
         @environment = @config.fetch(:environment)
+        @connection = Base.build_connection(open_timeout: open_timeout, read_timeout: read_timeout)
       end
 
       def domains
-        Domains.new(@config)
+        Domains.new(@config, connection: @connection)
       end
 
       def ssl
-        Ssl.new(@config)
+        Ssl.new(@config, connection: @connection)
       end
 
       def users
-        Users.new(@config)
+        Users.new(@config, connection: @connection)
       end
 
       def domain_privacy
-        DomainPrivacy.new(@config)
+        DomainPrivacy.new(@config, connection: @connection)
       end
 
       private
@@ -70,6 +77,15 @@ module Namecheap
         return if ENVIRONMENTS.include?(environment)
 
         raise ArgumentError, "environment must be sandbox or production"
+      end
+
+      def validate_timeout!(name, value)
+        valid = value.is_a?(Numeric) &&
+          value.respond_to?(:finite?) &&
+          value.finite? &&
+          value.respond_to?(:positive?) &&
+          value.positive?
+        raise ArgumentError, "#{name} must be a positive finite number" unless valid
       end
 
       def immutable_string(value)

--- a/lib/namecheap/api/domains.rb
+++ b/lib/namecheap/api/domains.rb
@@ -171,15 +171,15 @@ module Namecheap
       end
 
       def dns
-        Dns.new(@config)
+        Dns.new(@config, connection: @connection)
       end
 
       def nameservers
-        Nameservers.new(@config)
+        Nameservers.new(@config, connection: @connection)
       end
 
       def transfers
-        Transfers.new(@config)
+        Transfers.new(@config, connection: @connection)
       end
 
       private

--- a/lib/namecheap/api/users.rb
+++ b/lib/namecheap/api/users.rb
@@ -137,7 +137,7 @@ module Namecheap
       end
 
       def addresses
-        Addresses.new(@config)
+        Addresses.new(@config, connection: @connection)
       end
 
       private

--- a/spec/namecheap/api/client_spec.rb
+++ b/spec/namecheap/api/client_spec.rb
@@ -39,6 +39,81 @@ RSpec.describe Namecheap::API::Client do
     expect(configured.environment).to eq("production")
   end
 
+  it "configures safe default request timeouts" do
+    connection = instance_double(Faraday::Connection)
+    expect(Namecheap::API::Base).to receive(:build_connection)
+      .with(open_timeout: 5, read_timeout: 30)
+      .and_return(connection)
+
+    described_class.new(api_user: "api-user", api_key: "api-key", client_ip: "192.0.2.1")
+  end
+
+  it "accepts custom finite request timeouts" do
+    connection = instance_double(Faraday::Connection)
+    expect(Namecheap::API::Base).to receive(:build_connection)
+      .with(open_timeout: 0.5, read_timeout: 45)
+      .and_return(connection)
+
+    described_class.new(
+      api_user: "api-user",
+      api_key: "api-key",
+      client_ip: "192.0.2.1",
+      open_timeout: 0.5,
+      read_timeout: 45
+    )
+  end
+
+  it "maps open and read timeouts to Faraday connection options" do
+    connection = Namecheap::API::Base.build_connection(open_timeout: 0.5, read_timeout: 45)
+
+    expect(connection.options.open_timeout).to eq(0.5)
+    expect(connection.options.timeout).to eq(45)
+  end
+
+  {
+    zero: 0,
+    negative: -1,
+    nan: Float::NAN,
+    infinity: Float::INFINITY,
+    string: "30",
+    nil: nil,
+    complex: Complex(1, 1)
+  }.each do |description, value|
+    %i[open_timeout read_timeout].each do |option|
+      it "rejects a #{description} #{option}" do
+        expect do
+          described_class.new(
+            api_user: "api-user",
+            api_key: "api-key",
+            client_ip: "192.0.2.1",
+            **{option => value}
+          )
+        end.to raise_error(ArgumentError, "#{option} must be a positive finite number")
+      end
+    end
+  end
+
+  it "shares one connection with top-level and nested resources" do
+    connection = instance_double(Faraday::Connection)
+    allow(Namecheap::API::Base).to receive(:build_connection).and_return(connection)
+    configured = described_class.new(api_user: "api-user", api_key: "api-key", client_ip: "192.0.2.1")
+
+    resources = [
+      configured.domains,
+      configured.domains.dns,
+      configured.domains.nameservers,
+      configured.domains.transfers,
+      configured.ssl,
+      configured.users,
+      configured.users.addresses,
+      configured.domain_privacy
+    ]
+
+    expect(resources.map { |resource| resource.instance_variable_get(:@connection) })
+      .to all(be(connection))
+    expect(Namecheap::API::Base).to have_received(:build_connection).once
+  end
+
   %i[api_user api_key user_name client_ip].each do |option|
     it "rejects a blank #{option}" do
       options = {api_user: "api-user", api_key: "api-key", user_name: "account-user", client_ip: "192.0.2.1"}

--- a/spec/namecheap/api/response_spec.rb
+++ b/spec/namecheap/api/response_spec.rb
@@ -73,4 +73,22 @@ RSpec.describe Namecheap::API::Response do
         expect(error.message).not_to include("ApiKey")
       }
   end
+
+  it "raises a transport error for timeout failures" do
+    client = Namecheap::API::Client.new(
+      api_user: "api-user",
+      api_key: "api-key",
+      user_name: "account-user",
+      client_ip: "192.0.2.1"
+    )
+    stub_request(:get, Namecheap::API::Base::SANDBOX)
+      .with(query: hash_including("Command" => "namecheap.domains.getList"))
+      .to_raise(Faraday::TimeoutError.new("execution expired"))
+
+    expect { client.domains.get_list }
+      .to raise_error(Namecheap::API::TransportError, "Namecheap request failed: Faraday::TimeoutError") { |error|
+        expect(error.command).to eq("namecheap.domains.getList")
+        expect(error.message).not_to include("ApiKey")
+      }
+  end
 end


### PR DESCRIPTION
## Summary

- add validated `open_timeout` and `read_timeout` client options with safe defaults
- reuse one Faraday connection across top-level and nested resources
- preserve form-encoded POST behavior and translate timeout failures to `TransportError`
- document the public timeout behavior and clarify the repository's issue-branch workflow

Closes #19.

## Validation

- `mise exec -- bundle exec rake` — 103 examples, 0 failures
- `mise exec -- bundle exec standardrb`
- `mise exec -- bundle exec gem build namecheap.gemspec`
- `git diff --check`