### PR TITLE
Protect sensitive CLI output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,18 @@ sequence when choosing a branch name:
 7. After a topic branch has been merged, offer to delete both its local and
    remote copies. Do not delete either branch without the user's confirmation.
 
+## Remote Completion Gate
+
+For pull-request work, a successful local test run, commit, push, or PR creation
+does not constitute completion. After every push, inspect and wait for all
+required PR checks to reach a terminal state. If any check fails, inspect its
+logs, fix the cause, push the correction, and repeat.
+
+Report work as complete only when the remote branch contains the intended
+commit, every required check is present and green, and the PR diff contains only
+the intended files. While checks are pending, report the work as pending rather
+than complete.
+
 ## Security & Releases
 
 Never commit API keys, usernames, client IP configuration, or environment files containing credentials. Manual staging tests must load sandbox credentials from `.env.staging`; never use production credentials for them. Version changes, branch pushes, and gem builds do not constitute a release. A release requires a finalized changelog entry and an annotated signed `vVERSION` tag from `main` that GitHub reports as verified. Pushing that tag runs the release workflow, which validates the tag and publishes through RubyGems trusted publishing without a long-lived API key.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Add an agent-discoverable CLI with XDG profiles, env-file configuration, human/JSON/raw output, guarded paid actions, and drift-safe DNS record workflows.
 - Reach current-adjusted 0.3.1 command parity with registered nameserver, transfer, SSL, user, and domain-privacy resources.
 - Expose every API operation through the CLI, including structured private input for secrets and guarded unquotable charges.
+- Redact API keys, passwords, transfer and reset codes, and tokens consistently
+  across CLI responses, raw XML, previews, profiles, and errors.
 - Cover all 59 commands in Namecheap's current API catalog, including user addresses and the latest SSL operations.
 - Return normalized response objects with raw XML access and raise typed API, transport, and parse errors.
 - Add configurable open and read timeouts and reuse one Faraday connection

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bundle exec namecheap config profiles add sandbox
 bundle exec namecheap config profiles use sandbox
 ```
 
-Read commands default to human output; `--json` emits `{"data": ..., "meta": ...}` and `--raw` preserves the upstream XML. Mutating commands support `--dry-run` and ask for confirmation unless `--yes` is supplied. Registration and renewal require an exact API quote before confirmation. DNS record add, remove, and apply preserve the complete zone, show a diff, reject drift, and verify the submitted result.
+Read commands default to human output; `--json` emits `{"data": ..., "meta": ...}` and `--raw` emits upstream XML. When raw XML contains a recognized sensitive field, the CLI replaces the field and repeated copies of its value with `[redacted]`; use the Ruby API's `Response#raw_body` when exact programmatic access is required. Mutating commands support `--dry-run` and ask for confirmation unless `--yes` is supplied. Registration and renewal require an exact API quote before confirmation. DNS record add, remove, and apply preserve the complete zone, show a diff, reject drift, and verify the submitted result.
 
 Generate valid structured-input examples with commands such as:
 
@@ -232,6 +232,14 @@ prompt without echo; automation uses standard input or an input file accessible
 only by its owner. Paid commands use an exact pricing API quote when available.
 Domain-privacy renewal, for which Namecheap exposes no quote API, requires
 `--expected-price` and `--currency` and verifies the returned charge afterward.
+
+Runtime human, JSON, raw, preview, profile, and error output uses one recursive
+sensitive-field policy. API keys, passwords, EPP/auth codes, password reset
+codes, and tokens are rendered as `[redacted]`, including repeated copies inside
+other values such as redirect URLs. Matching uses an explicit normalized field
+list, so unrelated names such as `password_policy` and `tokenized` remain
+visible. Built-in examples contain documentation-only placeholders and are not
+runtime data.
 
 ## Roadmap
 

--- a/docs/standards/coding-style-conventions.md
+++ b/docs/standards/coding-style-conventions.md
@@ -62,7 +62,7 @@ structured data is required, and applicable safe smoke coverage.
 
 Update `script/cli_sandbox_smoke` whenever a CLI command is added or its syntax, output contract, or safety behavior changes. Exercise new read commands directly and mutation commands with `--dry-run` by default. If the sandbox cannot exercise a command, document the reason beside the smoke coverage and retain deterministic RSpec coverage. Keep `script/sandbox_smoke` updated independently for direct Ruby API coverage.
 
-Write normal results to stdout and prompts or errors to stderr. Preserve the JSON envelope (`data` and `meta`) and documented exit codes. Never accept an API key as a command-line option. Respect precedence in this order: command-line selectors, explicit env file, process environment, selected XDG profile, then sandbox defaults.
+Write normal results to stdout and prompts or errors to stderr. Preserve the JSON envelope (`data` and `meta`) and documented exit codes. CLI raw output preserves exact upstream XML only when no sensitive value requires redaction; `Response#raw_body` remains the exact Ruby API surface. Never accept an API key as a command-line option. Respect precedence in this order: command-line selectors, explicit env file, process environment, selected XDG profile, then sandbox defaults.
 
 All mutating commands support `--dry-run` and confirmation. Paid commands require an exact API quote. DNS record helpers must read the full zone, preview changes, re-read to detect drift, submit a complete replacement, and verify it afterward.
 
@@ -73,6 +73,13 @@ one-time tokens may be arguments only when explicitly justified and must still
 be redacted. When an upstream paid operation has no quote API, require an
 expected amount and currency, warn that the amount cannot be enforced before
 the charge, and compare it with the returned charge.
+
+Use the CLI sensitive-data policy for runtime structures, raw XML, and errors.
+Normalize field names before comparing them with the policy's exact list; never
+replace that comparison with substring or suffix matching. Parser diagnostics
+for sensitive inputs must identify the source and expected format without
+including parser excerpts or input content. Trusted built-in examples may keep
+obviously fake placeholders.
 
 ## Tests
 

--- a/lib/namecheap/cli/config_store.rb
+++ b/lib/namecheap/cli/config_store.rb
@@ -16,8 +16,8 @@ module Namecheap
           raise Error, "config must contain a mapping: #{path}" unless value.is_a?(Hash)
 
           {"version" => 1, "profiles" => {}, "contacts" => {}}.merge(value)
-        rescue Psych::Exception => error
-          raise Error, "invalid config: #{error.message}"
+        rescue Psych::Exception
+          raise Error, "invalid config at #{path}: expected valid YAML"
         end
       end
 

--- a/lib/namecheap/cli/env_file.rb
+++ b/lib/namecheap/cli/env_file.rb
@@ -2,12 +2,14 @@ module Namecheap
   module CLI
     module EnvFile
       def self.load(path)
-        File.readlines(path, chomp: true).each_with_object({}) do |line, values|
+        File.readlines(path, chomp: true).each_with_index.each_with_object({}) do |(line, index), values|
           line = line.strip
           next if line.empty? || line.start_with?("#")
 
           key, value = line.sub(/\Aexport\s+/, "").split("=", 2)
-          raise Error, "invalid env-file line: #{line}" unless key&.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/) && value
+          unless key&.match?(/\A[A-Za-z_][A-Za-z0-9_]*\z/) && value
+            raise Error, "invalid env file at #{path}: line #{index + 1} must be KEY=VALUE"
+          end
 
           values[key] = unquote(value.strip)
         end

--- a/lib/namecheap/cli/renderer.rb
+++ b/lib/namecheap/cli/renderer.rb
@@ -1,21 +1,29 @@
 require "json"
+require "namecheap/cli/sensitive_data"
 
 module Namecheap
   module CLI
     class Renderer
-      def initialize(io:, format:)
+      def initialize(io:, format:, sensitive_data: SensitiveData.new)
         @io = io
         @format = format
+        @sensitive_data = sensitive_data
       end
 
-      def render(data, meta: {})
+      def render(data, meta: {}, raw_xml: false)
+        if raw_xml
+          @io.puts(@sensitive_data.redact_xml(data))
+          return
+        end
+
+        output = @sensitive_data.redact("data" => data, "meta" => meta)
         case @format
         when :raw
-          @io.puts(data)
+          @io.puts(output.fetch("data"))
         when :json
-          @io.puts(JSON.pretty_generate("data" => data, "meta" => meta))
+          @io.puts(JSON.pretty_generate(output))
         else
-          human(data)
+          human(output.fetch("data"))
         end
       end
 

--- a/lib/namecheap/cli/runner.rb
+++ b/lib/namecheap/cli/runner.rb
@@ -9,6 +9,7 @@ require "namecheap/cli/config_store"
 require "namecheap/cli/env_file"
 require "namecheap/cli/error"
 require "namecheap/cli/renderer"
+require "namecheap/cli/sensitive_data"
 require "namecheap/cli/xml"
 
 module Namecheap
@@ -35,6 +36,7 @@ module Namecheap
         @stdin = stdin
         @env = env
         @shell = Thor::Shell::Basic.new
+        @sensitive_data = SensitiveData.new
       end
 
       def run(argv)
@@ -47,16 +49,19 @@ module Namecheap
         dispatch(command["path"], arguments)
         0
       rescue Error => error
-        @stderr.puts("Error: #{error.message}")
+        write_error(error)
         error.exit_code
       rescue Interrupt
         @stderr.puts("Interrupted")
         130
       rescue ArgumentError => error
-        @stderr.puts("Error: #{error.message}")
+        write_error(error)
         2
       rescue Namecheap::API::Error => error
-        @stderr.puts("Error: #{error.message}")
+        write_error(error)
+        1
+      rescue SensitiveData::UnsafeOutputError => error
+        write_error(error)
         1
       end
 
@@ -260,11 +265,12 @@ module Namecheap
         when "show"
           name = arguments.first || store.data["default_profile"] || raise(Error, "no default profile is selected")
           profile = store.profiles[name] || raise(Error, "profile not found: #{name}")
-          render(profile.merge("name" => name, "api_key" => profile["api_key"] ? "[redacted]" : nil))
+          render(profile.merge("name" => name))
         when "add"
           name = one_arg!(arguments)
           values = credentials_from_environment(@env)
           values["api_key"] ||= prompt_secret("API key")
+          @sensitive_data.register(values)
           %w[api_user api_key client_ip].each { |key| raise Error, "#{CREDENTIAL_ENV[key.to_sym]} must be set" if blank?(values[key]) }
           values["user_name"] ||= values["api_user"]
           values["environment"] ||= "sandbox"
@@ -494,7 +500,7 @@ module Namecheap
         domain = arguments.first
         document = load_document(arguments[1] || @options["--input"] || "-")
         contacts = contact_groups(document)
-        preview = {"operation" => "set contacts", "domain" => domain, "contacts" => redact(document)}
+        preview = {"operation" => "set contacts", "domain" => domain, "contacts" => document}
         return if dry_run!(preview)
 
         confirm!("Replace contacts for #{domain}?")
@@ -573,9 +579,9 @@ module Namecheap
         when "create"
           domain = one_arg!(arguments)
           input = if @options["--input"]
-            sensitive_document(@options["--input"], required: %w[epp_code])
+            sensitive_document(@options["--input"], required: %w[epp_code], context: "EPP code input")
           else
-            {"epp_code" => prompt_secret("EPP code")}
+            {"epp_code" => prompt_secret("EPP code")}.tap { |value| @sensitive_data.register(value) }
           end
           years = Integer(@options["--years"] || input["years"] || 1)
           _sld, tld = split_domain(domain)
@@ -808,8 +814,12 @@ module Namecheap
           require_args!(arguments, 0, exact: true)
           render_response(users.get_balances(params: api_params))
         when "create"
-          input = sensitive_document(input_path(arguments), required: %w[user_name password profile accept_terms])
-          mutate("create user", user_name: input["user_name"], profile: redact(input["profile"])) do
+          input = sensitive_document(
+            input_path(arguments),
+            required: %w[user_name password profile accept_terms],
+            context: "password input"
+          )
+          mutate("create user", user_name: input["user_name"], profile: input["profile"]) do
             users.create(
               user_name: input.fetch("user_name"),
               password: input.fetch("password"),
@@ -824,10 +834,18 @@ module Namecheap
           mutate("update user", profile: profile) { users.update(profile: profile, params: api_params) }
         when "login"
           path = optional_input_path(arguments)
-          input = path ? sensitive_document(path, required: %w[password]) : {"password" => prompt_secret("Password")}
+          input = if path
+            sensitive_document(path, required: %w[password], context: "password input")
+          else
+            {"password" => prompt_secret("Password")}.tap { |value| @sensitive_data.register(value) }
+          end
           render_response(users.login(password: input.fetch("password"), params: api_params))
         when "password change"
-          input = sensitive_document(input_path(arguments), required: %w[new_password])
+          input = sensitive_document(
+            input_path(arguments),
+            required: %w[new_password],
+            context: "password and reset code input"
+          )
           mutate("change user password") do
             users.change_password(
               new_password: input.fetch("new_password"),
@@ -856,7 +874,9 @@ module Namecheap
             )
           end
         when "funds status"
-          render_response(users.get_add_funds_status(token_id: one_arg!(arguments), params: api_params))
+          token_id = one_arg!(arguments)
+          @sensitive_data.register("token_id" => token_id)
+          render_response(users.get_add_funds_status(token_id: token_id, params: api_params))
         end
       end
 
@@ -1032,13 +1052,16 @@ module Namecheap
       end
 
       def render_response(body, meta = {})
-        value = @options["--raw"] ? body.raw_body : XML.parse(body)
         response_meta = meta.merge(
           "profile" => selected_profile,
           "environment" => resolved_config[:environment]
         )
         response_meta["paging"] = body.paging if body.paging
-        renderer.render(value, meta: response_meta)
+        if @options["--raw"]
+          renderer.render(body.raw_body, meta: response_meta, raw_xml: true)
+        else
+          renderer.render(XML.parse(body), meta: response_meta)
+        end
       end
 
       def render(data, meta: {})
@@ -1053,7 +1076,7 @@ module Namecheap
         else
           :human
         end
-        @renderer ||= Renderer.new(io: @stdout, format: format)
+        @renderer ||= Renderer.new(io: @stdout, format: format, sensitive_data: @sensitive_data)
       end
 
       def client
@@ -1066,6 +1089,9 @@ module Namecheap
           file_values = @options["--env-file"] ? EnvFile.load(@options["--env-file"]) : {}
           process_values = credentials_from_environment(@env)
           env_file_values = credentials_from_environment(file_values)
+          @sensitive_data.register(profile)
+          @sensitive_data.register(process_values)
+          @sensitive_data.register(env_file_values)
           merged = profile.merge(process_values).merge(env_file_values)
           merged["environment"] = @options["--environment"] if @options["--environment"]
           merged["environment"] ||= "sandbox"
@@ -1094,25 +1120,33 @@ module Namecheap
         type ? api_params.merge(field => type) : api_params
       end
 
-      def load_document(path)
+      def load_document(path, context: "input")
         content = (path == "-") ? @stdin.read : File.read(path)
-        value = if File.extname(path).downcase == ".json" || content.lstrip.start_with?("{", "[")
+        format = if File.extname(path).downcase == ".json" || content.lstrip.start_with?("{", "[")
+          "JSON"
+        else
+          "YAML"
+        end
+        value = if format == "JSON"
           JSON.parse(content)
         else
           YAML.safe_load(content, permitted_classes: [], aliases: false)
         end
         raise Error, "input must contain a mapping" unless value.is_a?(Hash)
-        value
+
+        @sensitive_data.register(value)
       rescue Errno::ENOENT
         raise Error, "input file not found: #{path}"
-      rescue JSON::ParserError, Psych::Exception => error
-        raise Error, "invalid input: #{error.message}"
+      rescue JSON::ParserError, Psych::Exception
+        source = (path == "-") ? "standard input" : path
+        expected = defined?(format) ? format : "JSON or YAML"
+        raise Error, "invalid #{context} at #{source}: expected valid #{expected}"
       end
 
-      def sensitive_document(path, required:)
+      def sensitive_document(path, required:, context:)
         @consumed_stdin = true if path == "-"
         check_private_file!(path) unless path == "-"
-        value = load_document(path)
+        value = load_document(path, context: context)
         missing = required.find { |key| blank?(value[key] || value[key.to_sym]) }
         raise Error, "input.#{missing} must be provided" if missing
 
@@ -1157,7 +1191,7 @@ module Namecheap
       end
 
       def mutate(operation, preview = {})
-        preview = redact(preview.merge("operation" => operation))
+        preview = preview.merge("operation" => operation)
         return if dry_run!(preview)
 
         confirm!("#{operation.capitalize}?")
@@ -1166,7 +1200,7 @@ module Namecheap
       end
 
       def paid_mutation(operation, quote)
-        preview = redact(quote.merge("operation" => operation))
+        preview = quote.merge("operation" => operation)
         return if dry_run!(preview)
 
         confirm!("#{operation.capitalize} for #{quote.fetch("price")} #{quote.fetch("currency")}?")
@@ -1201,20 +1235,6 @@ module Namecheap
         )
       end
 
-      def redact(value)
-        case value
-        when Hash
-          value.to_h do |key, child|
-            sensitive = key.to_s.match?(/api.?key|password|epp.?code|reset.?code|secret/i)
-            [key, sensitive ? "[redacted]" : redact(child)]
-          end
-        when Array
-          value.map { |child| redact(child) }
-        else
-          value
-        end
-      end
-
       def validate_contact!(contact)
         required = Namecheap::API::Domains::REQUIRED_CONTACT_FIELDS.map(&:to_s)
         missing = required.find { |field| blank?(contact[field] || contact[field.to_sym]) }
@@ -1244,6 +1264,16 @@ module Namecheap
         raise Error, "--raw cannot be combined with --dry-run" if @options["--raw"]
         render(preview, meta: {"dry_run" => true})
         true
+      end
+
+      def write_error(error)
+        if error.is_a?(Namecheap::API::ParseError)
+          message = "invalid API response"
+        else
+          @sensitive_data.register(error.response.to_h) if error.is_a?(Namecheap::API::ApiError)
+          message = @sensitive_data.redact_text(error.message)
+        end
+        @stderr.puts("Error: #{message}")
       end
 
       def split_domain(domain)

--- a/lib/namecheap/cli/sensitive_data.rb
+++ b/lib/namecheap/cli/sensitive_data.rb
@@ -1,0 +1,147 @@
+require "rexml/document"
+require "rexml/formatters/default"
+require "rexml/xpath"
+require "namecheap/api/key_normalizer"
+
+module Namecheap
+  module CLI
+    class SensitiveData
+      REDACTED = "[redacted]"
+      FIELD_NAMES = %w[
+        api_key
+        password
+        old_password
+        new_password
+        new_user_password
+        epp_code
+        auth_code
+        authorization_code
+        reset_code
+        token
+        token_id
+      ].freeze
+
+      class UnsafeOutputError < StandardError
+      end
+
+      def initialize
+        @values = []
+      end
+
+      def register(value)
+        discover(value)
+        value
+      end
+
+      def redact(value)
+        discover(value)
+        redact_value(value)
+      end
+
+      def redact_text(value)
+        @values.sort_by { |secret| -secret.length }.reduce(value.to_s) do |text, secret|
+          text.gsub(secret, REDACTED)
+        end
+      end
+
+      def redact_xml(value)
+        document = REXML::Document.new(value.to_s)
+        discover_xml(document)
+        changed = redact_xml_nodes(document)
+        return value unless changed
+
+        output = +""
+        REXML::Formatters::Default.new.write(document, output)
+        output
+      rescue REXML::ParseException
+        raise UnsafeOutputError, "raw API response could not be safely inspected"
+      end
+
+      private
+
+      def sensitive_field?(name)
+        FIELD_NAMES.include?(Namecheap::API::KeyNormalizer.snake(name))
+      end
+
+      def discover(value)
+        case value
+        when Hash
+          value.each do |key, child|
+            register_value(child) if sensitive_field?(key)
+            discover(child)
+          end
+        when Array
+          value.each { |child| discover(child) }
+        end
+      end
+
+      def register_value(value)
+        case value
+        when Hash
+          value.each_value { |child| register_value(child) }
+        when Array
+          value.each { |child| register_value(child) }
+        when String, Numeric
+          secret = value.to_s
+          @values << secret unless secret.empty? || secret == REDACTED || @values.include?(secret)
+        end
+      end
+
+      def redact_value(value)
+        case value
+        when Hash
+          value.to_h do |key, child|
+            [key, sensitive_field?(key) ? REDACTED : redact_value(child)]
+          end
+        when Array
+          value.map { |child| redact_value(child) }
+        when String
+          redact_text(value)
+        else
+          value
+        end
+      end
+
+      def discover_xml(document)
+        REXML::XPath.each(document, "//*") do |element|
+          element.attributes.each_attribute do |attribute|
+            register_value(attribute.value) if sensitive_field?(attribute.name)
+          end
+          register_value(element_text(element)) if sensitive_field?(element.name)
+        end
+      end
+
+      def element_text(element)
+        element.children.filter_map { |child| child.value if child.is_a?(REXML::Text) }.join
+      end
+
+      def redact_xml_nodes(document)
+        changed = false
+        REXML::XPath.each(document, "//*") do |element|
+          element.attributes.each_attribute do |attribute|
+            replacement = sensitive_field?(attribute.name) ? REDACTED : redact_text(attribute.value)
+            next if replacement == attribute.value
+
+            element.attributes[attribute.name] = replacement
+            changed = true
+          end
+
+          if sensitive_field?(element.name)
+            element.children.to_a.each { |child| element.delete(child) }
+            element.add_text(REDACTED)
+            changed = true
+          else
+            element.children.grep(REXML::Text).each do |text|
+              replacement = redact_text(text.value)
+              next if replacement == text.value
+
+              text.value = replacement
+              changed = true
+            end
+          end
+        end
+        changed
+      end
+    end
+  end
+end

--- a/script/cli_sandbox_smoke
+++ b/script/cli_sandbox_smoke
@@ -69,6 +69,9 @@ class CliSandboxSmoke
     check = invoke("domains", "check", check_domain, "--json")
     assert("domains check") { find_value(check["data"], "domain") == check_domain }
 
+    raw_check = invoke_raw("domains", "check", check_domain, "--raw")
+    assert("domains check raw output") { raw_check.include?("<ApiResponse") }
+
     price = invoke("domains", "price", check_domain, "--json")
     assert("domains price") do
       price.dig("data", "currency").to_s != "" && price.dig("data", "price").to_s != ""
@@ -103,6 +106,7 @@ class CliSandboxSmoke
 
   def validate_environment!
     values = Namecheap::CLI::EnvFile.load(@env_file)
+    @sensitive_values = [values["NAMECHEAP_API_KEY"]].compact.reject(&:empty?)
     environment = values.fetch("NAMECHEAP_ENVIRONMENT", "sandbox")
     raise "CLI sandbox smoke refuses environment=#{environment.inspect}" unless environment == "sandbox"
   end
@@ -112,11 +116,29 @@ class CliSandboxSmoke
     stderr = StringIO.new
     arguments += ["--env-file", @env_file] if credentials
     code = @cli.run(arguments, stdout: stdout, stderr: stderr, stdin: StringIO.new, env: ENV)
+    assert_no_sensitive_output!(stdout.string, stderr.string)
     raise "#{arguments.take_while { |argument| !argument.start_with?("--") }.join(" ")} failed: #{stderr.string.strip}" unless code == 0
 
     JSON.parse(stdout.string)
   rescue JSON::ParserError => error
     raise "#{arguments.join(" ")} returned invalid JSON: #{error.message}"
+  end
+
+  def invoke_raw(*arguments)
+    stdout = StringIO.new
+    stderr = StringIO.new
+    arguments += ["--env-file", @env_file]
+    code = @cli.run(arguments, stdout: stdout, stderr: stderr, stdin: StringIO.new, env: ENV)
+    assert_no_sensitive_output!(stdout.string, stderr.string)
+    raise "#{arguments.take_while { |argument| !argument.start_with?("--") }.join(" ")} failed" unless code == 0
+
+    stdout.string
+  end
+
+  def assert_no_sensitive_output!(*streams)
+    return unless @sensitive_values.any? { |value| streams.any? { |stream| stream.include?(value) } }
+
+    raise "CLI output contained a configured sensitive value"
   end
 
   def assert(label)

--- a/spec/namecheap/cli/renderer_spec.rb
+++ b/spec/namecheap/cli/renderer_spec.rb
@@ -1,0 +1,54 @@
+require "spec_helper"
+require "namecheap/cli/renderer"
+require "json"
+require "stringio"
+
+RSpec.describe Namecheap::CLI::Renderer do
+  def render(format, data, meta: {}, raw_xml: false)
+    output = StringIO.new
+    described_class.new(io: output, format: format).render(data, meta: meta, raw_xml: raw_xml)
+    output.string
+  end
+
+  it "redacts human output" do
+    output = render(:human, {"api_key" => "api-key-value", "secretary" => "Ada"})
+
+    expect(output).to include("Api Key: [redacted]", "Secretary: Ada")
+    expect(output).not_to include("api-key-value")
+  end
+
+  it "redacts JSON data and metadata through one boundary" do
+    output = render(
+      :json,
+      {"token_id" => "token-value-123", "url" => "https://example.test/token-value-123"},
+      meta: {"api_key" => "api-key-value"}
+    )
+    parsed = JSON.parse(output)
+
+    expect(parsed).to eq(
+      "data" => {
+        "token_id" => "[redacted]",
+        "url" => "https://example.test/[redacted]"
+      },
+      "meta" => {"api_key" => "[redacted]"}
+    )
+  end
+
+  it "redacts structured raw output" do
+    output = render(:raw, {"password" => "password-value", "password_policy" => "visible"})
+
+    expect(output).to include("\"password\"=>\"[redacted]\"", "\"password_policy\"=>\"visible\"")
+    expect(output).not_to include("password-value")
+  end
+
+  it "sanitizes raw XML output" do
+    output = render(
+      :raw,
+      "<Result TokenID=\"token-value-123\" URL=\"https://example.test/token-value-123\" />",
+      raw_xml: true
+    )
+
+    expect(output).to include("TokenID='[redacted]'", "https://example.test/[redacted]")
+    expect(output).not_to include("token-value-123")
+  end
+end

--- a/spec/namecheap/cli/renderer_spec.rb
+++ b/spec/namecheap/cli/renderer_spec.rb
@@ -37,7 +37,8 @@ RSpec.describe Namecheap::CLI::Renderer do
   it "redacts structured raw output" do
     output = render(:raw, {"password" => "password-value", "password_policy" => "visible"})
 
-    expect(output).to include("\"password\"=>\"[redacted]\"", "\"password_policy\"=>\"visible\"")
+    expect(output).to match(/"password"\s*=>\s*"\[redacted\]"/)
+    expect(output).to match(/"password_policy"\s*=>\s*"visible"/)
     expect(output).not_to include("password-value")
   end
 

--- a/spec/namecheap/cli/sensitive_data_spec.rb
+++ b/spec/namecheap/cli/sensitive_data_spec.rb
@@ -1,0 +1,95 @@
+require "spec_helper"
+require "namecheap/cli/sensitive_data"
+
+RSpec.describe Namecheap::CLI::SensitiveData do
+  subject(:sensitive_data) { described_class.new }
+
+  it "matches canonical sensitive field names across upstream spellings" do
+    value = {
+      "ApiKey" => "api-key-value",
+      "APIKey" => "alternate-api-key-value",
+      "OldPassword" => "old-password-value",
+      "NewUserPassword" => "new-password-value",
+      "EPPCode" => "epp-code-value",
+      "ResetCode" => "reset-code-value",
+      "TokenID" => "token-value",
+      "Authorization-Code" => "authorization-value"
+    }
+
+    expect(sensitive_data.redact(value).values.uniq).to eq(["[redacted]"])
+  end
+
+  it "redacts recursively without modifying the input" do
+    value = {
+      "items" => [
+        {"password" => "password-value"},
+        {"nested" => {"auth_code" => "authorization-value"}}
+      ]
+    }
+
+    redacted = sensitive_data.redact(value)
+
+    expect(redacted).to eq(
+      "items" => [
+        {"password" => "[redacted]"},
+        {"nested" => {"auth_code" => "[redacted]"}}
+      ]
+    )
+    expect(value.dig("items", 0, "password")).to eq("password-value")
+  end
+
+  it "scrubs discovered secrets from other string fields" do
+    value = {
+      "token_id" => "token-value-123",
+      "redirect_url" => "https://example.test/pay?tokenid=token-value-123"
+    }
+
+    expect(sensitive_data.redact(value)).to eq(
+      "token_id" => "[redacted]",
+      "redirect_url" => "https://example.test/pay?tokenid=[redacted]"
+    )
+  end
+
+  it "keeps unrelated fields visible" do
+    value = {
+      "password_policy" => "visible-password-policy",
+      "api_keyboard" => "visible-api-keyboard",
+      "epp_code_required" => true,
+      "tokenized" => "visible-tokenized",
+      "authorization_code_status" => "available",
+      "secretary" => "Ada"
+    }
+
+    expect(sensitive_data.redact(value)).to eq(value)
+  end
+
+  it "redacts sensitive XML fields and repeated values" do
+    xml = <<~XML
+      <ApiResponse>
+        <Result TokenID="token-value-123" RedirectURL="https://example.test/pay?tokenid=token-value-123">
+          <Password>password-value</Password>
+          <password_policy>visible</password_policy>
+        </Result>
+      </ApiResponse>
+    XML
+
+    redacted = sensitive_data.redact_xml(xml)
+
+    expect(redacted).to include("TokenID='[redacted]'")
+    expect(redacted).to include("tokenid=[redacted]")
+    expect(redacted).to include("<Password>[redacted]</Password>")
+    expect(redacted).to include("<password_policy>visible</password_policy>")
+    expect(redacted).not_to include("token-value-123", "password-value")
+  end
+
+  it "preserves exact XML when no redaction is needed" do
+    xml = "<Result Status=\"OK\" />\n"
+
+    expect(sensitive_data.redact_xml(xml)).to equal(xml)
+  end
+
+  it "fails closed for malformed raw XML" do
+    expect { sensitive_data.redact_xml("<Result TokenID=") }
+      .to raise_error(described_class::UnsafeOutputError, /could not be safely inspected/)
+  end
+end

--- a/spec/namecheap/cli_spec.rb
+++ b/spec/namecheap/cli_spec.rb
@@ -105,6 +105,159 @@ RSpec.describe Namecheap::CLI do
     expect(stdout).not_to include("api-key")
   end
 
+  it "redacts complete profiles in every output format" do
+    config = File.join(@directory, "config.yml")
+    File.write(
+      config,
+      <<~YAML
+        version: 1
+        profiles:
+          sandbox:
+            api_user: api-user
+            api_key: profile-api-key-value
+            password_policy: visible-policy
+            environment: sandbox
+      YAML
+    )
+
+    [[], ["--json"], ["--raw"]].each do |format|
+      code, stdout, stderr = run_cli("config", "profiles", "show", "sandbox", "--config", config, *format)
+
+      expect(code).to eq(0), stderr
+      expect(stdout).to include("[redacted]", "visible-policy")
+      expect(stdout).not_to include("profile-api-key-value")
+    end
+  end
+
+  it "returns safe diagnostics for malformed sensitive and credential inputs" do
+    password_file = File.join(@directory, "password.json")
+    File.write(password_file, %({"password": password-value-that-must-not-leak}))
+    File.chmod(0o600, password_file)
+
+    code, stdout, stderr = run_cli("users", "login", password_file, env: credentials)
+
+    expect(code).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("invalid password input", "expected valid JSON")
+    expect(stderr).not_to include("password-value-that-must-not-leak")
+
+    env_file = File.join(@directory, "credentials.env")
+    File.write(env_file, "NAMECHEAP_API_KEY credential-value-that-must-not-leak\n")
+
+    code, stdout, stderr = run_cli("domains", "check", "example.com", "--env-file", env_file)
+
+    expect(code).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("line 1 must be KEY=VALUE")
+    expect(stderr).not_to include("credential-value-that-must-not-leak")
+  end
+
+  it "never repeats transfer, reset, token, or authorization values from malformed documents" do
+    cases = [
+      [
+        "transfer.json",
+        %({"epp_code": epp-value-that-must-not-leak}),
+        ->(path) { ["domains", "transfers", "create", "example.com", "--input", path] }
+      ],
+      [
+        "password-change.json",
+        %({"new_password": "new", "reset_code": reset-value-that-must-not-leak}),
+        ->(path) { ["users", "password", "change", path] }
+      ],
+      [
+        "token.json",
+        %({"token": token-value-that-must-not-leak}),
+        ->(path) { ["domains", "check", "example.com", "--params", path] }
+      ],
+      [
+        "authorization.json",
+        %({"authorization_code": authorization-value-that-must-not-leak}),
+        ->(path) { ["domains", "check", "example.com", "--params", path] }
+      ]
+    ]
+
+    cases.each do |name, content, arguments|
+      path = File.join(@directory, name)
+      File.write(path, content)
+      File.chmod(0o600, path)
+
+      code, stdout, stderr = run_cli(*arguments.call(path), env: credentials)
+
+      expect(code).to eq(2)
+      expect(stdout).to be_empty
+      expect(stderr).to include("expected valid JSON")
+      expect(stderr).not_to include("value-that-must-not-leak")
+    end
+  end
+
+  it "returns a safe diagnostic for malformed configuration" do
+    config = File.join(@directory, "config.yml")
+    File.write(config, "profiles: [api-key-value-that-must-not-leak\n")
+
+    code, stdout, stderr = run_cli("config", "profiles", "list", "--config", config)
+
+    expect(code).to eq(2)
+    expect(stdout).to be_empty
+    expect(stderr).to include("expected valid YAML")
+    expect(stderr).not_to include("api-key-value-that-must-not-leak")
+  end
+
+  it "redacts returned tokens and copies embedded in URLs in every output format" do
+    response_xml = <<~XML
+      <ApiResponse Status="OK">
+        <CommandResponse>
+          <CreateAddFundsRequestResult
+            TokenID="returned-token-value-123"
+            RedirectURL="https://example.test/pay?tokenid=returned-token-value-123" />
+        </CommandResponse>
+      </ApiResponse>
+    XML
+    stub_request(:post, Namecheap::API::Base::SANDBOX).to_return(body: response_xml)
+
+    [[], ["--json"], ["--raw"]].each do |format|
+      code, stdout, stderr = run_cli(
+        "users", "funds", "request", "reseller-user",
+        "--amount", "40",
+        "--return-url", "https://example.test/return",
+        "--yes",
+        *format,
+        env: credentials
+      )
+
+      expect(code).to eq(0), stderr
+      expect(stdout).to include("[redacted]")
+      expect(stdout).not_to include("returned-token-value-123")
+    end
+  end
+
+  it "scrubs positional tokens from API errors" do
+    token = "submitted-token-value-123"
+    stub_request(:get, Namecheap::API::Base::SANDBOX)
+      .with(query: hash_including("Command" => "namecheap.users.getAddFundsStatus", "TokenId" => token))
+      .to_return(
+        body: <<~XML
+          <ApiResponse Status="ERROR">
+            <Errors><Error Number="2012342">TokenID #{token} did not match</Error></Errors>
+            <CommandResponse />
+          </ApiResponse>
+        XML
+      )
+
+    code, stdout, stderr = run_cli("users", "funds", "status", token, env: credentials)
+
+    expect(code).to eq(1)
+    expect(stdout).to be_empty
+    expect(stderr).to include("TokenID [redacted] did not match")
+    expect(stderr).not_to include(token)
+  end
+
+  it "keeps trusted placeholders in generated examples" do
+    code, stdout, stderr = run_cli("help", "users", "login", "--example", "password")
+
+    expect(code).to eq(0), stderr
+    expect(stdout).to include("replace-with-password")
+  end
+
   it "quotes exact domain pricing without making a purchase" do
     stub_request(:get, Namecheap::API::Base::SANDBOX)
       .with(query: hash_including("Command" => "namecheap.users.getPricing", "ActionName" => "REGISTER", "ProductName" => "COM"))

--- a/spec/script/cli_sandbox_smoke_spec.rb
+++ b/spec/script/cli_sandbox_smoke_spec.rb
@@ -20,7 +20,11 @@ RSpec.describe CliSandboxSmoke do
         def run(arguments, stdout:, **)
           @calls ||= []
           @calls << arguments
-          stdout.puts(JSON.generate(response(arguments)))
+          if arguments.include?("--raw")
+            stdout.puts("<ApiResponse Status=\"OK\" />")
+          else
+            stdout.puts(JSON.generate(response(arguments)))
+          end
           0
         end
 
@@ -62,8 +66,26 @@ RSpec.describe CliSandboxSmoke do
       array_including("users", "addresses", "list"),
       array_including("domain-privacy", "list"),
       array_including("dns", "records", "list"),
-      array_including("dns", "records", "add", "--dry-run")
+      array_including("dns", "records", "add", "--dry-run"),
+      array_including("domains", "check", "--raw")
     )
+  end
+
+  it "fails without repeating a configured API key when CLI output leaks it" do
+    environment_file.open
+    environment_file.truncate(0)
+    environment_file.write("NAMECHEAP_API_KEY=smoke-api-key-value\n")
+    environment_file.close
+    leaking_cli = Class.new do
+      def self.run(_arguments, stdout:, **)
+        stdout.puts("smoke-api-key-value")
+        0
+      end
+    end
+
+    expect do
+      described_class.new(env_file: environment_file.path, output: output, cli: leaking_cli).run
+    end.to raise_error(RuntimeError, "CLI output contained a configured sensitive value")
   end
 
   it "refuses a production environment file" do


### PR DESCRIPTION
## Summary

- centralize exact sensitive-field recognition and recursive value redaction
- protect human, JSON, structured raw, raw XML, profile, preview, and error output
- return safe parser diagnostics without exposing sensitive input content
- extend deterministic CLI and sandbox-smoke coverage

## Why

The CLI previously used broad substring matching in selected preview paths, while profile, raw, parser-error, and other output paths could bypass the same policy. A returned token could also remain visible when repeated inside another value such as a redirect URL.

The new request-scoped policy discovers values under an explicit normalized field list, redacts those fields, and removes repeated copies at the renderer and error boundaries. Built-in documentation placeholders remain unchanged, and the Ruby API continues to expose exact `Response#raw_body` content.

## Validation

- `mise exec -- bundle exec rake` — 122 examples, 0 failures; Standard Ruby passed
- `mise exec -- bundle exec gem build namecheap.gemspec` — built `namecheap-2.0.0.pre1.gem`
- verified the packaged gem includes the new CLI sensitive-data component

Closes #20